### PR TITLE
Changed auth token directory creation path

### DIFF
--- a/sal/client/main.py
+++ b/sal/client/main.py
@@ -322,7 +322,7 @@ class SALClient:
         c[self.host] = {'token': self.auth_token}
 
         # write tokens, creating file/folder if not present
-        os.makedirs(os.path.dirname(_AUTH_TOKEN_CACHE), exist_ok=True)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             c.write(f)
 


### PR DESCRIPTION
**Description**
Minor adjustment to `SALClient._write_auth_token` which fixes were token directory is written.

**Fixes**
Fixes #33 

**To test**
In any directory other than the home directory (e.g. ~), import `SALClient` and connect to a SAL server which has authentication enabled.  Then call any `SALClient` method which requires authentication and input username and password and see if an error is thrown.