### PR TITLE
Corrected _clear_auth_token path

### DIFF
--- a/sal/client/main.py
+++ b/sal/client/main.py
@@ -341,7 +341,7 @@ class SALClient:
         c.remove_section(self.host)
 
         # write tokens, creating file/folder if not present
-        os.makedirs(os.path.dirname(_AUTH_TOKEN_CACHE), exist_ok=True)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             c.write(f)
 


### PR DESCRIPTION
**Description**
Minor change to fix incorrect path in `SALClient._clear_auth_token`.  The same as #34 did for `SALClient._write_auth_token`.

The fact that this fix has to be applied in two different places is indicative that the auth token methods need refactoring.  See #36

**Fixes**
Fixes #35 

**To test**
Clear an auth token.  Must be executed from any directory apart from home. 
