### PR TITLE
SAL Server returns custom exceptions

### DIFF
--- a/sal/core/exception.py
+++ b/sal/core/exception.py
@@ -1,3 +1,5 @@
+from werkzeug.exceptions import HTTPException
+
 # base exception
 class SALException(Exception):
 
@@ -9,34 +11,56 @@ class SALException(Exception):
         message = message if message else self.message
         super().__init__(message, *args, **kwargs)
 
+class SALHTTPException(HTTPException, SALException):
+
+    """
+    Base SAL specific HTTP exception
+    
+    Inherits from ``HTTPException`` first as we want it to use that `__init__`
+
+    Inheriting from both means it will be caught if either ``HTTPException`` or
+    ``SALException``
+
+    Inheriting from ``HTTPException`` means it will have an associated status
+    code (`code`) which can be handled by Flask
+    """
+
+    pass
 
 # server side exceptions
-class InvalidPath(SALException):
-    message = 'Path does not conform to path specification.'
+class InvalidPath(SALHTTPException):
+    code = 404
+    description = 'Path does not conform to path specification.'
 
 
 class NodeNotFound(SALException):
-    message = 'The supplied path does not point to a valid node.'
+    code = 404
+    description = 'The supplied path does not point to a valid node.'
 
 
 class UnsupportedOperation(SALException):
-    message = 'Operation is not supported.'
+    code = 500
+    description = 'Operation is not supported.'
 
 
 class InvalidRequest(SALException):
-    message = 'The request sent to the server could not be handled.'
+    code = 400
+    description = 'The request sent to the server could not be handled.'
 
 
 class AuthenticationFailed(SALException):
-    message = 'Valid authorisation credentials were not supplied.'
+    code = 401
+    description = 'Valid authorisation credentials were not supplied.'
 
 
 class PermissionDenied(SALException):
-    message = 'The user does not have permission to perform this operation.'
+    code = 403
+    description = 'The user does not have permission to perform this operation.'
 
 
 class InternalError(SALException):
-    message = 'An error occurred affecting server operation. Please contact your administrator.'
+    code = 500
+    description = 'An error occurred affecting server operation. Please contact your administrator.'
 
 
 # client side exceptions

--- a/sal/server/api.py
+++ b/sal/server/api.py
@@ -1,0 +1,19 @@
+from flask.json import jsonify
+from flask_restful import Api
+
+class ErrorHandlerApi(Api):
+
+    """
+    Subclasses flask_restul.Api to add error handling 
+    """
+
+    def handle_error(self, e):
+        """
+        Converts the error (including any custom messages/description) to JSON
+
+        :param e: The exception to handle
+        :type e: werkzeug.exceptions.HTTPException
+        :return: Tuple of JSON equivalent of `e` and its status code
+        """
+
+        return jsonify({"message":str(e)}), e.code

--- a/sal/server/api.py
+++ b/sal/server/api.py
@@ -16,4 +16,5 @@ class ErrorHandlerApi(Api):
         :return: Tuple of JSON equivalent of `e` and its status code
         """
 
-        return jsonify({"message":str(e)}), e.code
+        return jsonify({"message":str(e),
+                        "class":e.__class__.__name__}), e.code

--- a/sal/server/api.py
+++ b/sal/server/api.py
@@ -17,4 +17,4 @@ class ErrorHandlerApi(Api):
         """
 
         return jsonify({"message":str(e),
-                        "class":e.__class__.__name__}), e.code
+                        "exception":e.__class__.__name__}), e.code

--- a/sal/server/main.py
+++ b/sal/server/main.py
@@ -1,8 +1,8 @@
 from flask import Flask
-from flask_restful import Api
 
 from sal.core.version import VERSION as RELEASE_VERSION
 from sal.core import exception
+from sal.server.api import ErrorHandlerApi
 from sal.server.interface import PersistenceProvider, AuthenticationProvider, AuthorisationProvider
 from sal.server.resource import ServerInfo, DataTree, Authenticator
 from sal.dataclass import *
@@ -46,47 +46,8 @@ class SALServer(Flask):
             'API_VERSION': API_VERSION
         }
 
-        # exception handling mapping table
-        error_map = {
-            'InvalidRequest': {
-                'message': exception.InvalidRequest.message,
-                'status': 400,
-                'exception': 'InvalidRequest'
-            },
-            'AuthenticationFailed': {
-                'message': exception.AuthenticationFailed.message,
-                'status': 401,
-                'exception': 'AuthenticationFailed'
-            },
-            'PermissionDenied': {
-                'message': exception.PermissionDenied.message,
-                'status': 403,
-                'exception': 'PermissionDenied'
-            },
-            'InvalidPath': {
-                'message': exception.InvalidPath.message,
-                'status': 404,
-                'exception': 'InvalidPath'
-            },
-            'NodeNotFound': {
-                'message': exception.NodeNotFound.message,
-                'status': 404,
-                'exception': 'NodeNotFound'
-            },
-            'UnsupportedOperation': {
-                'message': exception.UnsupportedOperation.message,
-                'status': 500,
-                'exception': 'UnsupportedOperation'
-            },
-            'InternalError': {
-                'message': exception.InternalError.message,
-                'status': 500,
-                'exception': 'InternalError'
-            },
-        }
-
         # build api
-        api = Api(self, errors=error_map)
+        api = ErrorHandlerApi(self)
         api.add_resource(ServerInfo, '/')
         api.add_resource(DataTree, '/data', '/data/', '/data/<path:path>')
         api.add_resource(Authenticator, '/auth', '/auth/')


### PR DESCRIPTION
### Description
Enables the SAL server to respond with custom exceptions messages i.e., if a SAL exception is initialised with a message (e.g. `NodeNotFound('This is a custom message')`, that message will be displayed in the client.

This required:
- Adding a `SALHTTPException` which subclasses `werkzeug.exception.HTTPException` as well as `SALException`.  This allows any classing inheriting from SALHTTPException to define a `code` (HTTP status code) and a `description`.
- Changed from using `flask_restful.Api` to a subclass which customises exception handling by the `Api`.
- Removing the `error_map` which was passed to `flask_restful.Api`.    

### Fixes

Fixes #46 

### To test
- [ ] Ensure that the exceptions which derive from SALHTTPException have the correct `code` values.
- [ ] Create a simple SAL server (i.e., just define a simple PersistenceProvider) and test that it can respond with custom exception messages.
- [ ] Check that standard exception messages are still returned if a custom exception message is not provided (i.e., if an exception is initialised without a message).
- [ ] Check that the changes are sufficiently documented.