### PR TITLE
77 pylint errors

### DIFF
--- a/sal/core/tests/test_path.py
+++ b/sal/core/tests/test_path.py
@@ -1,6 +1,6 @@
 import unittest
 
-import jetserver.jetvfs.path as pth
+from sal.core import path as pth
 
 VALID_SEGMENTS = [
     "abcdefghijklmnopqrstuvwxyz._-01234567890",

--- a/sal/dataclass/signal/error/asymmetric.py
+++ b/sal/dataclass/signal/error/asymmetric.py
@@ -109,7 +109,7 @@ class AsymmetricArrayError(Error):
             raise ValueError('The dictionary does not contain a serialised asymmetrical array error class.')
 
         if d['lower'].dtype != d['upper'].dtype:
-            raise ValueError('Cannot deserialise, lower and upper data types are inconsistent (lower: {}, upper: {})'.format(d['lower'].dtype), dtype=d['upper'].dtype)
+            raise ValueError('Cannot deserialise, lower and upper data types are inconsistent (lower: {}, upper: {})'.format(d['lower'].dtype, d['upper'].dtype))
 
         c = cls(
             lower=d['lower'],


### PR DESCRIPTION
<!---
Please select any labels relevant to this merge request.

If a merge request is a work in progress, please prefix the name with WIP:

Once completed and ready for review, remove WIP: from the name and assign a reviewer.
--->

### Description of work

Fix two errors detected by pylint.

**Note: Correcting the import path in `sal.core.tests.test_path` does not cause the tests to pass.  This is not a concern as the path testing will be addressed in #71. **

### Fixes

<!-- A list of issues fixed by this MR (e.g., Fixes #1, #2). -->

Fixes #77 

### To test

- [x] Run `pylint -E sal/` and check that there are no erros.

### Reviewer checklist

<!-- This section should be completed by one of the reviewers. -->

- [x] The author suggested tests are successful.