### PR TITLE
Fix use of deprecated numpy fromstring functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,181 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/build/
+docs/source/autoapi/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm-project.org/#use-with-ide
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# ruff
+.ruff_cache/
+
+# Cython debug symbols
+cython_debug/
+
+# Editor files
+#mac
+.DS_Store
+*~
+
+#vim
+*.swp
+*.swo
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+#VSCode
+.vscode/
+
+*.whl
+junit.xml

--- a/sal/core/serialise.py
+++ b/sal/core/serialise.py
@@ -299,7 +299,7 @@ def _decode_array(d):
         raise InternalError('Malformed array data found during de-serialisation.')
 
     if encoding == 'base64':
-        return _np.fromstring(base64.b64decode(data), dtype=dtype).reshape(shape)
+        return _np.frombuffer(base64.b64decode(data), dtype=dtype).reshape(shape)
 
     if encoding == 'list':
         return _np.array(data, dtype=dtype)

--- a/sal/dataclass/core/string.py
+++ b/sal/dataclass/core/string.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from sal.core.object import DataObject, DataSummary, dataclass
 
 # TODO: add tests


### PR DESCRIPTION
### Description of work

- Remove unused import
- Use `numpy.frombuffer` rather than `numpy.fromstring` as the latter is deprecated

### Fixes

- Use of deprecated `numpy.fromstring`, see deprecation note under `sep` in [docs](https://numpy.org/doc/2.1/reference/generated/numpy.fromstring.html)

### Reproduce deprecation note

Note deprecation warning is hidden by sal, can be seen by installing `numpy>=1.14` and running:

```python
import numpy as np
np.fromstring(b'abc', dtype=np.int8)
```

### To test

- Test getting a signal from a concrete SAL server.
- Note that unit tests do not cover `_decode_array` so running them will not test this change. 

### Reviewer checklist

<!-- This section should be completed by one of the reviewers. -->

- [ ] The author suggested tests are successful.
- [ ] Relevant documentation (user and developer) has been added, and is clear and complete.
- [ ] Suitable unit tests have been added.  If unit tests are not included in this MR, please comment as to why and create an issue to address this. 
